### PR TITLE
chore: gradle 8.14, kotlin 2.2.0, intellij platform 2.7.0 업그레이드

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK
         uses: actions/setup-java@v3

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ bin/
 .DS_Store
 
 .intellijPlatform/
+CLAUDE.md

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,12 +2,12 @@ import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
     id("java")
-    id("org.jetbrains.kotlin.jvm") version "1.9.0"
-    id("org.jetbrains.intellij.platform") version "2.0.0"
+    id("org.jetbrains.kotlin.jvm") version "2.2.0"
+    id("org.jetbrains.intellij.platform") version "2.7.0"
 }
 
 group = "com.moseoh"
-version = "0.0.18"
+version = "0.0.19"
 
 repositories {
     mavenCentral()
@@ -18,12 +18,11 @@ repositories {
 }
 dependencies {
     intellijPlatform {
-        intellijIdeaUltimate("2024.2")
+        intellijIdeaUltimate("2025.2")
 
         bundledPlugin("com.intellij.java")
         pluginVerifier()
         zipSigner()
-        instrumentationTools()
 
         testFramework(TestFrameworkType.Platform)
     }
@@ -36,23 +35,17 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
 }
 
-tasks {
-    // Set the JVM compatibility versions
-    withType<JavaCompile> {
-        sourceCompatibility = "17"
-        targetCompatibility = "17"
-    }
-    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        kotlinOptions.jvmTarget = "17"
-    }
+kotlin {
+    jvmToolchain(21)
+}
 
+tasks {
     withType<Test> {
         useJUnitPlatform()
     }
 
     patchPluginXml {
         sinceBuild.set("231.*")
-        untilBuild.set("242.*")
     }
 
     signPlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,1 @@
 kotlin.stdlib.default.dependency=false
-# TODO temporary workaround for Kotlin 1.8.20+ (https://jb.gg/intellij-platform-kotlin-oom)
-kotlin.incremental.useClasspathSnapshot=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
-networkTimeout=10000
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
**Summary**

* 개발 환경을 최신 버전으로 업그레이드하여 성능과 안정성 개선
* 최신 IntelliJ Platform API 지원 및 JVM toolchain 적용

**Changes**

* Gradle 8.2 → 8.14로 업그레이드
* Kotlin 1.9.0 → 2.2.0으로 업그레이드
* IntelliJ Platform Plugin 2.0.0 → 2.7.0으로 업그레이드
* JVM 17 → JVM 21로 업그레이드 및 toolchain 적용
* GitHub Actions checkout v3 → v4로 업데이트
* 불필요한 Kotlin 설정 및 untilBuild 제약 제거
* CLAUDE.md를 .gitignore에 추가